### PR TITLE
Add configurable Whisper model, language, and auto-download support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ htmlcov/
 # Cache for downloaded YouTube audio files from youtube_tool.py
 testing/audio_cache/
 
+# Whisper model files
+models/
+
 # Environment variables
 .env
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ communicating with an MCP server.
 
   After installation, make sure the `whisper-cli` (or `whisper-cpp` on older versions) command is in your PATH.
 
-  Finally, download a Whisper model. The **tiny** model offers the best speed-to-quality ratio for most use-cases:
+  Models are **automatically downloaded** on first use — no manual setup needed. If you prefer to pre-download a model:
 
   ```bash
   mkdir -p models
@@ -42,7 +42,7 @@ communicating with an MCP server.
        https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin
   ```
 
-  Place additional models in the same `models/` folder if you wish to experiment.
+  To use a different model, set the `WHISPER_MODEL` environment variable (see [Configuration](#configuration)).
 
 ## Installation with `uv`
 
@@ -229,7 +229,7 @@ Here is an example of a `call_tool` request to get a transcript for the query "W
 
 **Request:**
 
-```json 
+```json
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -238,15 +238,17 @@ Here is an example of a `call_tool` request to get a transcript for the query "W
     "name": "get_youtube_transcript",
     "arguments": {
       "query": "What is an API? by MuleSoft",
-      "force_whisper": false
+      "force_whisper": false,
+      "language": "en"
     }
   }
 }
-``` 
+```
 
 * `query`: The search term for the YouTube video.
 * `force_whisper`: (Optional) A boolean that, if `true`, skips the check for an official transcript and generates one
   directly with Whisper. Defaults to `false`.
+* `language`: (Optional) Language code for transcription (e.g., `en`, `ja`, `zh`). Overrides the `WHISPER_LANGUAGE` environment variable. Defaults to auto-detect.
 
 ## Testing
 
@@ -265,6 +267,17 @@ This project includes a test suite to verify its functionality.
   ```
 
 ## Configuration
+
+The server can be configured via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WHISPER_MODEL` | `tiny` | Whisper model to use. Options: `tiny`, `base`, `small`, `medium`, `large-v2`, `large-v3`, `large-v3-turbo` |
+| `WHISPER_MODEL_DIR` | `./models` | Directory for storing model files |
+| `WHISPER_LANGUAGE` | `auto` | Default language for transcription (e.g., `en`, `ja`, `zh`). Can be overridden per-request via the `language` tool parameter |
+| `WHISPER_THREADS` | CPU core count | Number of threads for whisper.cpp |
+
+Models are **automatically downloaded** from HuggingFace on first use if not already present in the model directory.
 
 * **Logging:** Server activity is logged to `mcp_server.log`.
 * **Audio Cache:** When Whisper is used, downloaded audio files are temporarily stored in `testing/audio_cache/`. You

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -64,6 +64,10 @@ try:
                             "type": "boolean",
                             "description": "Force the use of Whisper for transcription, even if an official transcript is available",
                             "default": False
+                        },
+                        "language": {
+                            "type": "string",
+                            "description": "Language code for transcription (e.g., 'en', 'ja', 'zh'). Defaults to auto-detect."
                         }
                     },
                     "required": ["query"]
@@ -90,10 +94,11 @@ try:
             raise ValueError("Missing required argument: query")
 
         force_whisper = arguments.get("force_whisper", False)
+        language = arguments.get("language")
 
         try:
             # The import is no longer here. We just call the function directly.
-            result = get_youtube_transcript(query=query, force_whisper=force_whisper)
+            result = get_youtube_transcript(query=query, force_whisper=force_whisper, language=language)
             logging.info(f"youtube_tool returned with status: {result.get('status')}")
 
             if result.get("status") == "success":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,8 @@ dependencies = [
     "mcp",
     "pytube"
 ]
+
+[dependency-groups]
+dev = [
+    "pytest",
+]

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -1,0 +1,149 @@
+"""Unit tests for Whisper configuration and model download logic."""
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from youtube_tool import VALID_MODELS, WHISPER_CPP_FILENAMES, _download_model, _get_config
+
+
+# --- _get_config() ---
+
+
+class TestGetConfig:
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv("WHISPER_MODEL", raising=False)
+        monkeypatch.delenv("WHISPER_MODEL_DIR", raising=False)
+        monkeypatch.delenv("WHISPER_LANGUAGE", raising=False)
+
+        config = _get_config()
+
+        assert config["model_name"] == "tiny"
+        assert config["model_dir"].endswith("models")
+        assert config["language"] == "auto"
+
+    @pytest.mark.parametrize("model", VALID_MODELS)
+    def test_valid_models(self, monkeypatch, model):
+        monkeypatch.setenv("WHISPER_MODEL", model)
+        config = _get_config()
+        assert config["model_name"] == model
+
+    def test_invalid_model_raises(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_MODEL", "nonexistent")
+        with pytest.raises(ValueError, match="Invalid WHISPER_MODEL"):
+            _get_config()
+
+    def test_custom_model_dir(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_MODEL_DIR", "/tmp/my-models")
+        config = _get_config()
+        assert config["model_dir"] == "/tmp/my-models"
+
+    def test_custom_language(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_LANGUAGE", "ja")
+        config = _get_config()
+        assert config["language"] == "ja"
+
+    def test_whitespace_stripped(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_MODEL", "  base  ")
+        monkeypatch.setenv("WHISPER_LANGUAGE", " zh ")
+        config = _get_config()
+        assert config["model_name"] == "base"
+        assert config["language"] == "zh"
+
+    def test_empty_model_dir_uses_default(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_MODEL_DIR", "   ")
+        config = _get_config()
+        assert config["model_dir"].endswith("models")
+
+
+# --- _download_model() ---
+
+
+class TestDownloadModel:
+    def test_existing_model_returns_path(self, tmp_path):
+        model_file = tmp_path / "ggml-tiny.bin"
+        model_file.write_bytes(b"fake model data")
+
+        result = _download_model("tiny", str(tmp_path))
+
+        assert result == str(model_file)
+
+    def test_missing_model_triggers_download(self, tmp_path):
+        target = tmp_path / "ggml-base.bin"
+
+        def fake_urlretrieve(url, path, reporthook=None):
+            with open(path, "wb") as f:
+                f.write(b"downloaded model")
+
+        with patch("youtube_tool.urllib.request.urlretrieve", side_effect=fake_urlretrieve):
+            result = _download_model("base", str(tmp_path))
+
+        assert result == str(target)
+        assert target.exists()
+        assert not (tmp_path / "ggml-base.bin.downloading").exists()
+
+    def test_download_failure_cleans_up(self, tmp_path):
+        with patch("youtube_tool.urllib.request.urlretrieve", side_effect=ConnectionError("network down")):
+            with pytest.raises(RuntimeError, match="Failed to download model"):
+                _download_model("small", str(tmp_path))
+
+        assert not (tmp_path / "ggml-small.bin.downloading").exists()
+        assert not (tmp_path / "ggml-small.bin").exists()
+
+    def test_creates_model_dir_if_missing(self, tmp_path):
+        new_dir = tmp_path / "sub" / "models"
+
+        def fake_urlretrieve(url, path, reporthook=None):
+            with open(path, "wb") as f:
+                f.write(b"data")
+
+        with patch("youtube_tool.urllib.request.urlretrieve", side_effect=fake_urlretrieve):
+            _download_model("tiny", str(new_dir))
+
+        assert new_dir.exists()
+
+
+# --- WHISPER_CPP_FILENAMES ---
+
+
+class TestFilenameMapping:
+    def test_all_models_have_filenames(self):
+        for model in VALID_MODELS:
+            assert model in WHISPER_CPP_FILENAMES
+            assert WHISPER_CPP_FILENAMES[model] == f"ggml-{model}.bin"
+
+
+# --- MCP handler language passthrough ---
+
+
+class TestMcpLanguagePassthrough:
+    def test_language_passed_to_function(self):
+        with patch("mcp_server.get_youtube_transcript") as mock_fn:
+            mock_fn.return_value = {"status": "success", "title": "T", "url": "U", "source": "S", "transcript": "text"}
+
+            from mcp_server import handle_call_tool
+
+            asyncio.run(handle_call_tool("get_youtube_transcript", {
+                "query": "test",
+                "language": "zh",
+            }))
+
+            mock_fn.assert_called_once_with(query="test", force_whisper=False, language="zh")
+
+    def test_language_none_when_omitted(self):
+        with patch("mcp_server.get_youtube_transcript") as mock_fn:
+            mock_fn.return_value = {"status": "success", "title": "T", "url": "U", "source": "S", "transcript": "text"}
+
+            from mcp_server import handle_call_tool
+
+            asyncio.run(handle_call_tool("get_youtube_transcript", {
+                "query": "test",
+            }))
+
+            mock_fn.assert_called_once_with(query="test", force_whisper=False, language=None)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -179,6 +179,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -534,6 +543,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -602,6 +629,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -1017,6 +1069,11 @@ dependencies = [
     { name = "yt-dlp" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mcp" },
@@ -1025,6 +1082,9 @@ requires-dist = [
     { name = "youtube-transcript-api" },
     { name = "yt-dlp" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
 
 [[package]]
 name = "yt-dlp"

--- a/youtube_tool.py
+++ b/youtube_tool.py
@@ -284,7 +284,8 @@ def get_youtube_transcript(query: str, force_whisper: bool = False, language: st
         if not force_whisper and video_id:
             logger.info("Attempting to fetch official YouTube transcript...")
             try:
-                transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+                api = YouTubeTranscriptApi()
+                transcript_list = api.list(video_id)
                 # Prioritize manually created transcripts, then auto-generated
                 transcript_obj = None
                 for t in transcript_list:
@@ -298,9 +299,9 @@ def get_youtube_transcript(query: str, force_whisper: bool = False, language: st
                         break  # Found best option, exit loop
 
                 if transcript_obj:
-                    # Fetch the actual transcript parts
-                    transcript_parts = transcript_obj.fetch()
-                    transcript_text = " ".join([item.text for item in transcript_parts])
+                    # Fetch the actual transcript using the selected language
+                    fetched = api.fetch(video_id, languages=[transcript_obj.language_code])
+                    transcript_text = " ".join([snippet.text for snippet in fetched])
                     transcript_source = f"Official YouTube Captions ({'Generated' if transcript_obj.is_generated else 'Manual'})"
                     logger.info("Successfully fetched official YouTube transcript.")
                 else:


### PR DESCRIPTION
## Summary

- **Environment variable configuration**: Add `WHISPER_MODEL`, `WHISPER_MODEL_DIR`, and `WHISPER_LANGUAGE` env vars to configure Whisper behavior without modifying source code
- **Auto-download models**: Automatically download whisper.cpp models from HuggingFace on first use if not present locally
- **Language parameter**: Add `language` parameter to the MCP tool schema, allowing per-request language override
- **Fix youtube-transcript-api v1.x compatibility**: Migrate from deprecated `list_transcripts()` class method to the new `YouTubeTranscriptApi()` instance API
- **Unit tests**: Add 20 tests covering config validation, model download logic, and MCP handler language passthrough

## Changes

| File | Description |
|------|-------------|
| `youtube_tool.py` | Add `_get_config()`, `_download_model()`, parameterize `_transcribe_with_whisper_cpp()`, update `get_youtube_transcript()` signature, fix
youtube-transcript-api v1.x usage |
| `mcp_server.py` | Add `language` property to tool schema, pass it through handler |
| `README.md` | Add configuration table, auto-download docs, language parameter docs |
| `pyproject.toml` | Add pytest dev dependency |
| `testing/test_config.py` | New unit test suite |

## Test plan

- [x] `pytest testing/test_config.py` — 20 tests all passing
- [x] MCP integration test — verified whisper.cpp transcription works end-to-end
- [x] youtube-transcript-api v1.x — verified official transcript fetching works with new API